### PR TITLE
Support for image title in markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "./node_modules/.bin/mocha ./testing/setup.js \"./lib/**/*/__tests__/*.js\" \"./lib/__tests__/*.js\" \"./syntaxes/**/*/__tests__/*.js\" --bail --reporter=list --timeout=10000"
+    "test": "./node_modules/.bin/mocha ./testing/setup.js \"./lib/**/*/__tests__/*.js\" \"./lib/__tests__/*.js\" \"./syntaxes/**/*/__tests__/*.js\" --reporter=list --timeout=10000"
   },
   "repository": {
     "type": "git",

--- a/syntaxes/markdown/__tests__/specs.js
+++ b/syntaxes/markdown/__tests__/specs.js
@@ -46,17 +46,12 @@ function testMdToHtml(fixture) {
 
 function testMdIdempotence(fixture) {
     var content1 = markdown.toContent(fixture.sourceMd);
-
     var backToMd = markdown.toText(content1);
     var content2 = markdown.toContent(backToMd);
 
-    backToMd = markdown.toText(content2);
-    var content3 = markdown.toContent(backToMd);
-
+    var resultHtml1 = html.toText(content1);
     var resultHtml2 = html.toText(content2);
-    var resultHtml3 = html.toText(content3);
-
-    (resultHtml2).should.be.html(resultHtml3);
+    (resultHtml1).should.be.html(resultHtml2);
 }
 
 function readFixture(filename) {

--- a/syntaxes/markdown/__tests__/specs/image.html
+++ b/syntaxes/markdown/__tests__/specs/image.html
@@ -1,0 +1,5 @@
+<p>
+  <img alt="first alt" src="/first.jpg" title="first title">
+  <img alt="second alt" src="/second.jpg">
+  <img alt="third alt" src="/third.jpg">
+</p>

--- a/syntaxes/markdown/__tests__/specs/image.md
+++ b/syntaxes/markdown/__tests__/specs/image.md
@@ -1,0 +1,3 @@
+![first alt](/first.jpg "first title")
+![second alt](/second.jpg "")
+![third alt](/third.jpg)

--- a/syntaxes/markdown/inline.js
+++ b/syntaxes/markdown/inline.js
@@ -27,19 +27,30 @@ var inlineRules = MarkupIt.RulesSet([
                 return;
             }
 
+            var imgData = {
+                alt: match[1],
+                src: match[2]
+            };
+
+            var title = match[3];
+            if(typeof title !== 'undefined' && title !== '') {
+              imgData.title = title;
+            }
+
             return {
-                data: {
-                    alt: match[1],
-                    src: match[2]
-                }
+              data: imgData
             };
         })
         .toText(function(state, token) {
             var data = token.getData();
             var alt  = data.get('alt', '');
             var src  = data.get('src', '');
-
-            return '![' + alt + '](' + src + ')';
+            var title = data.get('title', '');
+            if(title !== '') {
+                return '![' + alt + '](' + src + ' "' + title + '")';
+            } else {
+                return '![' + alt + '](' + src + ')';
+            }
         }),
 
     // ---- LINK ----


### PR DESCRIPTION
This PR adds support for image titles in markdown sources. Till now, only alt text and src of image has been processed and title has been ignored. Following (standard) format is now supported:

```md
![alt text](link/to/image.jpg "title text")
```

It also fixes MdIdempotence check, which caused successful tests even for incorrect conditions. 