### PR TITLE
[Slate] Text nodes should be wrapped in ranges

### DIFF
--- a/lib/slate/__tests__/block-data/expected.yaml
+++ b/lib/slate/__tests__/block-data/expected.yaml
@@ -6,13 +6,15 @@ nodes:
         id: hey
     nodes:
       - kind: text
-        text: Hello
-        marks: []
+        ranges:
+          - text: Hello
+            marks: []
   - kind: block
     type: paragraph
     isVoid: false
     data: {}
     nodes:
       - kind: text
-        text: World
-        marks: []
+        ranges:
+          - text: World
+            marks: []

--- a/lib/slate/__tests__/block-void/expected.yaml
+++ b/lib/slate/__tests__/block-void/expected.yaml
@@ -5,8 +5,9 @@ nodes:
     data: {}
     nodes:
       - kind: text
-        text: Hello
-        marks: []
+        ranges:
+          - text: Hello
+            marks: []
   - kind: block
     type: hr
     isVoid: true
@@ -18,5 +19,6 @@ nodes:
     data: {}
     nodes:
       - kind: text
-        text: World
-        marks: []
+        ranges:
+          - text: World
+            marks: []

--- a/lib/slate/__tests__/bold-link/expected.yaml
+++ b/lib/slate/__tests__/bold-link/expected.yaml
@@ -5,8 +5,9 @@ nodes:
     data: {}
     nodes:
       - kind: text
-        text: Hello
-        marks: []
+        ranges:
+          - text: Hello
+            marks: []
       - kind: inline
         type: link
         isVoid: false
@@ -14,10 +15,12 @@ nodes:
             href: https://google.com
         nodes:
           - kind: text
-            text: World
-            marks:
-                - type: BOLD
-                  data: {}
+            ranges:
+              - text: World
+                marks:
+                    - type: BOLD
+                      data: {}
       - kind: text
-        text: !
-        marks: []
+        ranges:
+          - text: !
+            marks: []

--- a/lib/slate/__tests__/bold/expected.yaml
+++ b/lib/slate/__tests__/bold/expected.yaml
@@ -5,13 +5,12 @@ nodes:
     data: {}
     nodes:
       - kind: text
-        text: Hello
-        marks: []
-      - kind: text
-        text: World
-        marks:
-            - type: BOLD
-              data: {}
-      - kind: text
-        text: "!"
-        marks: []
+        ranges:
+          - text: Hello
+            marks: []
+          - text: World
+            marks:
+              - type: BOLD
+                data: {}
+          - text: "!"
+            marks: []

--- a/lib/slate/__tests__/link-bold/expected.yaml
+++ b/lib/slate/__tests__/link-bold/expected.yaml
@@ -5,8 +5,9 @@ nodes:
     data: {}
     nodes:
       - kind: text
-        text: Hello
-        marks: []
+        ranges:
+          - text: Hello
+            marks: []
       - kind: inline
         type: link
         isVoid: false
@@ -14,10 +15,12 @@ nodes:
             href: https://google.com
         nodes:
           - kind: text
-            text: World
-            marks:
-                - type: BOLD
-                  data: {}
+            ranges:
+              - text: World
+                marks:
+                    - type: BOLD
+                      data: {}
       - kind: text
-        text: !
-        marks: []
+        ranges:
+          - text: !
+            marks: []

--- a/lib/slate/__tests__/link/expected.yaml
+++ b/lib/slate/__tests__/link/expected.yaml
@@ -5,8 +5,9 @@ nodes:
     data: {}
     nodes:
       - kind: text
-        text: Hello
-        marks: []
+        ranges:
+          - text: Hello
+            marks: []
       - kind: inline
         type: link
         isVoid: false
@@ -14,8 +15,10 @@ nodes:
             href: https://google.com
         nodes:
           - kind: text
-            text: World
-            marks: []
+            ranges:
+              - text: World
+                marks: []
       - kind: text
-        text: !
-        marks: []
+        ranges:
+          - text: !
+            marks: []

--- a/lib/slate/__tests__/paragraphs/expected.yaml
+++ b/lib/slate/__tests__/paragraphs/expected.yaml
@@ -5,13 +5,15 @@ nodes:
     data: {}
     nodes:
       - kind: text
-        text: Hello
-        marks: []
+        ranges:
+          - text: Hello
+            marks: []
   - kind: block
     type: paragraph
     isVoid: false
     data: {}
     nodes:
       - kind: text
-        text: World
-        marks: []
+        ranges:
+          - text: World
+            marks: []

--- a/lib/slate/encode.js
+++ b/lib/slate/encode.js
@@ -74,6 +74,34 @@ function encodeInlineTokenToNodes(token, marks) {
 }
 
 /**
+ * Wraps a sequence of text nodes into `ranges` array.
+ *
+ * @param {Array<JSONNode>} nodes
+ * @return {Array<JSONNode>} nodes
+ */
+function wrapTextNodes(nodes) {
+    return nodes.reduce(function(accu, node){
+        if(node.kind === KINDS.TEXT){
+            var prevIndex = accu.length - 1;
+            delete node.kind;
+            if(prevIndex >= 0 && accu[prevIndex] && accu[prevIndex]['kind'] === KINDS.TEXT){
+                accu[prevIndex].ranges = accu[prevIndex].ranges.concat(node);
+                return accu;
+            } else {
+                return accu.concat([
+                    {
+                        kind: KINDS.TEXT,
+                        ranges: [node]
+                    }
+                ]);
+            }
+        } else {
+            return accu.concat(node);
+        }
+    },[]);
+}
+
+/**
  * Encode a token (block or inline) to a Slate node.
  *
  * @param {Token} token
@@ -85,13 +113,16 @@ function encodeTokenToNodes(token, marks) {
         return encodeInlineTokenToNodes(token, marks);
     }
 
+    var nodes = encodeTokensToNodes(token.getTokens(), marks);
+    var wrapedNodes = wrapTextNodes(nodes);
+
     return [
         {
             kind:   token.isBlock()? KINDS.BLOCK : KINDS.INLINE,
             type:   token.getType(),
             data:   token.getData().toJS(),
             isVoid: isVoid(token),
-            nodes:  encodeTokensToNodes(token.getTokens(), marks)
+            nodes:  wrapedNodes
         }
     ];
 }


### PR DESCRIPTION
Slate's Raw serializer expects texts to be represented as "ranges" (https://github.com/ianstormtaylor/slate/blob/master/docs/reference/serializers/raw.md)

This pull request includes:

* A new method `wrapTextNodes` to wrap consecutive text nodes into a single text node with multiple ranges. 
* Updated tests to expect texts wrapped in ranges.