### PR TITLE
Small Improvements to custom rules support

### DIFF
--- a/lib/models/rules.js
+++ b/lib/models/rules.js
@@ -40,7 +40,7 @@ RulesSet.prototype.add = function(newRules) {
     newRules = RulesList(newRules);
 
     // Concat rules
-    rules = rules.concat(newRules);
+    rules = newRules.concat(rules);
 
     return this.set('rules', rules);
 };

--- a/lib/slate/encode.js
+++ b/lib/slate/encode.js
@@ -119,12 +119,13 @@ function encodeTokensToNodes(tokens, marks) {
  * @return {JSONDoc} doc
  */
 function encodeContentToSlate(content, markTypes, voidNodes) {
-
-    if (markTypes !== null && markTypes !== undefined && markTypes instanceof Immutable.List) {
+    if ( markTypes !== null && markTypes !== undefined &&
+       (markTypes instanceof Immutable.List || markTypes instanceof Array)) {
         MARK_TYPES = MARK_TYPES.concat(markTypes);
     }
 
-    if (voidNodes !== null && voidNodes !== undefined && voidNodes instanceof Immutable.List) {
+    if (voidNodes !== null && voidNodes !== undefined &&
+       (voidNodes instanceof Immutable.List || voidNodes instanceof Array)) {
         VOID_NODES = VOID_NODES.concat(voidNodes);
     }
 

--- a/lib/slate/encode.js
+++ b/lib/slate/encode.js
@@ -114,9 +114,20 @@ function encodeTokensToNodes(tokens, marks) {
  * Encode a Content into a Slate Raw JSON object
  *
  * @param {Content} content
+ * @param {markTypes} optional. Add custom MARK_TYPES to encode
+ * @param {voidNodes} optional. Add custom VOID_NODES to encode
  * @return {JSONDoc} doc
  */
-function encodeContentToSlate(content) {
+function encodeContentToSlate(content, markTypes, voidNodes) {
+
+    if (markTypes !== null && markTypes !== undefined && markTypes instanceof Immutable.List) {
+        MARK_TYPES = MARK_TYPES.concat(markTypes);
+    }
+
+    if (voidNodes !== null && voidNodes !== undefined && voidNodes instanceof Immutable.List) {
+        VOID_NODES = VOID_NODES.concat(voidNodes);
+    }
+
     var nodes = encodeTokenToNodes(content.getToken());
     var doc = nodes[0];
 


### PR DESCRIPTION
This PR contain two commits regarding the ability to dynamically add custom rules to existing syntaxes.

* Prioritize added rules
New, User-created rules added to an existing syntax (such as the MarkDown syntax) should be processed before the pre-existing rules. (Otherwise pre-existing rules with broad matching patterns will always be used instead of the custom rule added in userland).

* Let the user specify custom marks and void nodes with Slate utils `encode`

