### PR TITLE
Fix parsing starting indent of code fences

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-dom": "^15.3.2",
     "rtrim": "0.0.3",
     "split-lines": "^1.1.0",
+    "trim-newlines": "^1.0.0",
     "trim-right": "^1.0.1",
     "trim-trailing-lines": "^1.1.0",
     "type-of": "^2.0.1",

--- a/src/markdown/blocks/code.js
+++ b/src/markdown/blocks/code.js
@@ -1,3 +1,4 @@
+const trimNewlines = require('trim-newlines');
 const { Serializer, Deserializer, Block, BLOCKS } = require('../../');
 const deserializeCodeLines = require('../../utils/deserializeCodeLines');
 const reBlock = require('../re/block');
@@ -49,8 +50,8 @@ const serialize = Serializer()
  */
 const deserializeFences = Deserializer()
     .matchRegExp(reBlock.fences, (state, match) => {
-        // Extract code block text
-        const text = match[3].trim();
+        // Extract code block text, and trim empty lines
+        const text = trimNewlines(match[3]);
 
         // Extract language syntax
         let data;

--- a/test/from-markdown/code-blocks/no-syntax-start-indent/input.md
+++ b/test/from-markdown/code-blocks/no-syntax-start-indent/input.md
@@ -1,0 +1,3 @@
+```
+    Hello World
+```

--- a/test/from-markdown/code-blocks/no-syntax-start-indent/output.yaml
+++ b/test/from-markdown/code-blocks/no-syntax-start-indent/output.yaml
@@ -1,0 +1,9 @@
+nodes:
+  - kind: block
+    type: code_block
+    nodes:
+      - kind: block
+        type: code_line
+        nodes:
+          - kind: text
+            text: '    Hello World'

--- a/test/from-markdown/lists/ul-loose/input.md
+++ b/test/from-markdown/lists/ul-loose/input.md
@@ -1,11 +1,12 @@
 * Item 1
 
-    ```
-    Item 1 text
-    ```
+  ```
+  Item 1 text
+  Some other text
+  ```
 
 * Item 2
 
-    ```
-    Item 2 text
-    ```
+  ```
+  Item 2 text
+  ```

--- a/test/from-markdown/lists/ul-loose/output.yaml
+++ b/test/from-markdown/lists/ul-loose/output.yaml
@@ -18,6 +18,11 @@ nodes:
                 nodes:
                   - kind: text
                     text: "Item 1 text"
+              - kind: block
+                type: code_line
+                nodes:
+                  - kind: text
+                    text: "Some other text"
       - kind: block
         type: list_item
         nodes:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2883,6 +2883,10 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+trim-newlines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"


### PR DESCRIPTION
From markdown:

    ```js
       indented first line
    etc.
    ```

was losing the starting indentation:

```js
indented first line
etc.
```

