### PR TITLE
Fix #55: markdown with html serialization

### DIFF
--- a/src/markdown/inlines/html.js
+++ b/src/markdown/inlines/html.js
@@ -46,7 +46,9 @@ const serialize = Serializer()
     .matchType(INLINES.HTML)
     .then(state => {
         const node = state.peek();
-        return node.shift().write(node.text);
+        return state
+            .shift()
+            .write(node.data.get('html'));
     });
 
 /**

--- a/src/markdown/inlines/html.js
+++ b/src/markdown/inlines/html.js
@@ -39,6 +39,38 @@ function createHTML(html) {
 }
 
 /**
+ * Merge consecutive HTML nodes.
+ * @param  {List<Node>} nodes
+ * @return {List<Node>} nodes
+ */
+function mergeHTMLNodes(nodes) {
+    const result = nodes.reduce(
+        (accu, node) => {
+            let last = accu.length > 0 ? accu[accu.length - 1] : null;
+
+            if (last && node.type == INLINES.HTML && last.type == node.type) {
+                last = last.merge({
+                    data: last.data.set(
+                        'html',
+                        last.data.get('html') + node.data.get('html')
+                    )
+                });
+
+                accu.shift();
+                accu.push(last);
+
+                return accu;
+            }
+
+            return accu.concat([ node ]);
+        },
+        []
+    );
+
+    return List(result);
+}
+
+/**
  * Serialize an HTML node to markdown
  * @type {Serializer}
  */
@@ -86,6 +118,8 @@ const deserialize = Deserializer()
         if (endTag) {
             nodes = nodes.push(createHTML(endTag));
         }
+
+        nodes = mergeHTMLNodes(nodes);
 
         return state.push(nodes);
     });

--- a/test/from-markdown/html/p-not-merged/input.md
+++ b/test/from-markdown/html/p-not-merged/input.md
@@ -1,0 +1,1 @@
+<p>Hello</p> World <p>!</p>

--- a/test/from-markdown/html/p-not-merged/output.yaml
+++ b/test/from-markdown/html/p-not-merged/output.yaml
@@ -1,0 +1,20 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+      - kind: inline
+        isVoid: true
+        type: html
+        data:
+          html: "<p>Hello</p>"
+      - kind: text
+        text: " World "
+      - kind: inline
+        isVoid: true
+        type: html
+        data:
+          html: "<p>!</p>"
+      - kind: text
+        text: ""

--- a/test/from-markdown/html/p/input.md
+++ b/test/from-markdown/html/p/input.md
@@ -1,0 +1,1 @@
+<p>Hello <a href="https://www.google.com">World</a> !</p>

--- a/test/from-markdown/html/p/output.yaml
+++ b/test/from-markdown/html/p/output.yaml
@@ -1,0 +1,27 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+      - kind: inline
+        isVoid: true
+        type: html
+        data:
+          html: "<p>"
+      - kind: text
+        text: ""
+      - kind: inline
+        isVoid: true
+        type: html
+        data:
+          html: "Hello <a href=\"https://www.google.com\">World</a> !"
+      - kind: text
+        text: ""
+      - kind: inline
+        isVoid: true
+        type: html
+        data:
+          html: "</p>"
+      - kind: text
+        text: ""

--- a/test/from-markdown/html/p/output.yaml
+++ b/test/from-markdown/html/p/output.yaml
@@ -8,20 +8,6 @@ nodes:
         isVoid: true
         type: html
         data:
-          html: "<p>"
-      - kind: text
-        text: ""
-      - kind: inline
-        isVoid: true
-        type: html
-        data:
-          html: "Hello <a href=\"https://www.google.com\">World</a> !"
-      - kind: text
-        text: ""
-      - kind: inline
-        isVoid: true
-        type: html
-        data:
-          html: "</p>"
+          html: "<p>Hello <a href=\"https://www.google.com\">World</a> !</p>"
       - kind: text
         text: ""

--- a/test/to-markdown/html/p/input.yaml
+++ b/test/to-markdown/html/p/input.yaml
@@ -1,0 +1,13 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+      - kind: inline
+        isVoid: true
+        type: html
+        data:
+          html: "<p>Hello <a href=\"https://www.google.com\">World</a> !</p>"
+      - kind: text
+        text: ""

--- a/test/to-markdown/html/p/output.md
+++ b/test/to-markdown/html/p/output.md
@@ -1,0 +1,1 @@
+<p>Hello <a href="https://www.google.com">World</a> !</p>


### PR DESCRIPTION
Serialization of nodes with `INLINES.HTML` as failing in markdown.

This PR fixes it (Fix #55) and also merge consecutive HTML nodes into one (much better if we want to support edition in the editor).