### PR TITLE
Fix empty code block

### DIFF
--- a/src/markdown/re/block.js
+++ b/src/markdown/re/block.js
@@ -11,7 +11,7 @@ const block = {
     footnote:   /^\[\^([^\]]+)\]: ([^\n]+)/,
     paragraph:  /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def|math))+)\n*/,
     text:       /^[^\n]+/,
-    fences:     /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?[\s]*)\n *\1 *(?:\n|$)/,
+    fences:     /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n(?:([\s\S]*?)\n|)\1 *(?:\n+|$)/,
     yamlHeader: /^ *(?=```)/,
     math:       /^ *(\${2,}) *(\n+[\s\S]+?)\s*\1 *(?:\n|$)/,
     list:       {

--- a/src/markdown/re/block.js
+++ b/src/markdown/re/block.js
@@ -11,7 +11,7 @@ const block = {
     footnote:   /^\[\^([^\]]+)\]: ([^\n]+)/,
     paragraph:  /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def|math))+)\n*/,
     text:       /^[^\n]+/,
-    fences:     /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n(?:([\s\S]*?)\n|)\1 *(?:\n+|$)/,
+    fences:     /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,
     yamlHeader: /^ *(?=```)/,
     math:       /^ *(\${2,}) *(\n+[\s\S]+?)\s*\1 *(?:\n|$)/,
     list:       {

--- a/test/from-markdown/code-blocks/empty/input.md
+++ b/test/from-markdown/code-blocks/empty/input.md
@@ -1,0 +1,9 @@
+```java
+
+```
+
+Hello world
+
+```java
+Second
+```

--- a/test/from-markdown/code-blocks/empty/output.yaml
+++ b/test/from-markdown/code-blocks/empty/output.yaml
@@ -1,0 +1,26 @@
+nodes:
+  - kind: block
+    type: code_block
+    data:
+      syntax: java
+    nodes:
+      - kind: block
+        type: code_line
+        nodes:
+          - kind: text
+            text: ""
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "Hello world"
+  - kind: block
+    type: code_block
+    data:
+      syntax: java
+    nodes:
+      - kind: block
+        type: code_line
+        nodes:
+          - kind: text
+            text: "Second"


### PR DESCRIPTION
This PR fixes parsing of empty code blocks.

It updates the regex using the latest in [marked](https://github.com/chjj/marked/blob/master/lib/marked.js#L78) (since markupit is based on kramed, which is based on marked)