### PR TITLE
Fix URI decoding

### DIFF
--- a/src/markdown/utils.js
+++ b/src/markdown/utils.js
@@ -79,7 +79,18 @@ function escapeURL(str) {
  * @return {String}
  */
 function unescapeURL(str) {
-    return unescapeWith(URL_REPLACEMENTS_UNESCAPE, decodeURI(str));
+    let decoded;
+    try {
+        decoded = decodeURI(str);
+    } catch (e) {
+        if (!(e instanceof URIError)) {
+            throw e;
+        } else {
+            decoded = str;
+        }
+    }
+
+    return unescapeWith(URL_REPLACEMENTS_UNESCAPE, decoded);
 }
 
 

--- a/test/all.js
+++ b/test/all.js
@@ -121,7 +121,16 @@ function isTestFolder(folder) {
     const inputName = files.find(file => file.split('.')[0] === 'input');
     const outputName = files.find(file => file.split('.')[0] === 'output');
 
-    return Boolean(inputName && outputName);
+    const input = Boolean(inputName);
+    const output = Boolean(outputName);
+
+    if (input && !output) {
+        throw new Error(`It looks like the test '${folder}' has an ${inputName} file, but is missing an output file.`);
+    } else if (!input && output) {
+        throw new Error(`It looks like the test '${folder}' has an ${outputName} file, but is missing an output file.`);
+    }
+
+    return input && output;
 }
 
 /**

--- a/test/from-markdown/links/url-with-encoded-parenthesis/output.yaml
+++ b/test/from-markdown/links/url-with-encoded-parenthesis/output.yaml
@@ -1,0 +1,15 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "This is a "
+      - kind: inline
+        type: link
+        data:
+          href: "hello(world).md"
+        nodes:
+          - kind: text
+            text: 'link'
+      - kind: text
+        text: ""

--- a/test/from-markdown/links/url-with-malformed-encoding/input.md
+++ b/test/from-markdown/links/url-with-malformed-encoding/input.md
@@ -1,0 +1,1 @@
+This is a [malformed link](https://test.com/hello{%)

--- a/test/from-markdown/links/url-with-malformed-encoding/output.yaml
+++ b/test/from-markdown/links/url-with-malformed-encoding/output.yaml
@@ -1,0 +1,15 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "This is a "
+      - kind: inline
+        type: link
+        data:
+          href: "https://test.com/hello{%"
+        nodes:
+          - kind: text
+            text: 'malformed link'
+      - kind: text
+        text: ""


### PR DESCRIPTION
There was an issue with the content 
```
{% youtube %}https://www.youtube.com/watch?v=1Uv1Kmvhtc4{% endyoutube %}
```
that would try to parse the following link `https://www.youtube.com/watch?v=1Uv1Kmvhtc4{%` and fail at decoding URI.

This avoid this failure, and adds detection of incomplete test folders.

I'll look into the templating parsing issue as well in another PR.