### PR TITLE
Fix: sanitize non-breaking spaces

### DIFF
--- a/src/html/deserializeHtml.js
+++ b/src/html/deserializeHtml.js
@@ -296,7 +296,8 @@ function parse(str) {
         },
 
         ontext(text) {
-            const textNode = Text.createFromString(text, marks);
+            const cleanText = sanitizeSpaces(text);
+            const textNode = Text.createFromString(cleanText, marks);
             appendNode(textNode);
         },
 
@@ -345,6 +346,17 @@ function parse(str) {
 
     const rootNodes = stack.peek().nodes;
     return List(rootNodes);
+}
+
+/*
+ * sanitizeSpaces replace non-breaking spaces with regular space
+ * non-breaking spaces (aka &nbsp;) are sources of many problems & quirks
+ * &nbsp; in ascii is `0xA0` or `0xC2A0` in utf8
+ * @param {String} str
+ * @return {String}
+ */
+function sanitizeSpaces(str) {
+    return str.replace(/\xa0/g, ' ');
 }
 
 /**

--- a/test/from-html/dirty-nbsp/input.html
+++ b/test/from-html/dirty-nbsp/input.html
@@ -1,0 +1,4 @@
+<body>
+    <h1>Heading&nbsp;1</h1>
+    <p>Something<span>&nbsp;</span>else</p>
+</body>

--- a/test/from-html/dirty-nbsp/output.yaml
+++ b/test/from-html/dirty-nbsp/output.yaml
@@ -1,0 +1,11 @@
+nodes:
+  - kind: block
+    type: header_one
+    nodes:
+      - kind: text
+        text: "Heading 1"
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "Something else"

--- a/test/from-html/real-world-list/output.yaml
+++ b/test/from-html/real-world-list/output.yaml
@@ -15,11 +15,11 @@ nodes:
               nodes:
                 - kind: text
                   ranges:
-                    - text: 'An '
+                    - text: 'An '
                     - text: 'Account'
                       marks:
                         - type: BOLD
-                    - text: ' is what you use to login to Algolia. Each team member should have a separate account, secured with Two-Factor-Authentication.'
+                    - text: ' is what you use to login to Algolia. Each team member should have a separate account, secured with Two-Factor-Authentication.'
 
         - kind: block
           type: list_item
@@ -29,7 +29,7 @@ nodes:
               nodes:
                 - kind: text
                   ranges:
-                    - text: 'Each team member can have access to one or multiple '
+                    - text: 'Each team member can have access to one or multiple '
                     - text: 'Applications'
                       marks:
                         - type: BOLD

--- a/test/from-html/real-world-rich/output.yaml
+++ b/test/from-html/real-world-rich/output.yaml
@@ -8,11 +8,11 @@ nodes:
           - text: 'Dub Incorporation'
             marks:
               - type: BOLD
-          - text: ' (since 2006 just '
+          - text: ' (since 2006 just '
           - text: 'Dub Inc'
             marks:
               - type: BOLD
-          - text: ') is a '
+          - text: ') is a '
       - kind: inline
         type: link
         data:


### PR DESCRIPTION
Unexpected non-breaking spaces in a document can cause lots of quirks and issues.

People never really expect or desire docs to contain non-breaking spaces, but browsers create them when copy/pasting HTML

This PR replaces all non-breaking spaces with regular spaces when parsing HTML