### PR TITLE
Parse hr before lists

### DIFF
--- a/src/markdown/blocks/index.js
+++ b/src/markdown/blocks/index.js
@@ -15,12 +15,12 @@ const custom = require('./custom');
 module.exports = [
     definition,
     table,
+    hr,
     list,
     footnote,
     blockquote,
     codeBlock,
     heading,
-    hr,
     math,
     comment,
     custom,

--- a/test/from-markdown/hr/with-spaces/input.md
+++ b/test/from-markdown/hr/with-spaces/input.md
@@ -1,0 +1,5 @@
+Hello
+
+- - -
+
+World

--- a/test/from-markdown/hr/with-spaces/output.yaml
+++ b/test/from-markdown/hr/with-spaces/output.yaml
@@ -1,0 +1,17 @@
+document:
+  nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+            - text: Hello
+    - kind: block
+      type: hr
+      isVoid: true
+    - kind: block
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+            - text: World


### PR DESCRIPTION
Otherwise, HRs are considered as lists in case they include spaces.
Example:
```md
Hello

- - -

World
```

becomes:
```
Hello

-
  -

World
```