### PR TITLE
Fix: Inconsistent inline HTML parsing

### DIFF
--- a/test/from-markdown/html/no-line-break/input.md
+++ b/test/from-markdown/html/no-line-break/input.md
@@ -1,0 +1,3 @@
+<br/>
+<p>Something</p>
+<br/>

--- a/test/from-markdown/html/no-line-break/output.yaml
+++ b/test/from-markdown/html/no-line-break/output.yaml
@@ -1,0 +1,42 @@
+document:
+  nodes:
+
+    - kind: block
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+            - text: ''
+        - kind: inline
+          type: html
+          isVoid: true
+          data:
+            html: <br/>
+          nodes:
+            - kind: text
+              ranges:
+                - text: ' '
+        - kind: text
+          ranges:
+            - text: "\n"
+        - kind: inline
+          type: html
+          isVoid: true
+          data:
+            html: <p>Something</p>
+          nodes:
+            - kind: text
+              ranges:
+                - text: ' '
+        - kind: text
+          ranges:
+            - text: "\n"
+        - kind: inline
+          type: html
+          isVoid: true
+          data:
+            html: <br/>
+          nodes:
+            - kind: text
+              ranges:
+                - text: ' '


### PR DESCRIPTION
This reveals an issue with HTML parsing:

The following Markdown:

```md
<br/>
<p>Something</p>
<br/>
```

is parsed as:

```jsx
<paragraph>
  <html html="<br/>" />
</paragraph>
<paragraph>
  <html html="<p>Something</p>" />
  <html html="<br/>" />
</paragraph>
```

instead of

```jsx
<paragraph>
  <html html="<br/>" />
  <html html="<p>Something</p>" />
  <html html="<br/>" />
</paragraph>
```

or even better:

```jsx
<paragraph>
  <html html="<br/>" />
</paragraph>
<paragraph>
  <html html="<p>Something</p>" />
</paragraph>
<paragraph>
  <html html="<br/>" />
</paragraph>
```