### PR TITLE
Fix whitespace escaping in markdown links

### DIFF
--- a/src/markdown/utils.js
+++ b/src/markdown/utils.js
@@ -33,6 +33,7 @@ const URL_REPLACEMENTS_UNESCAPE = REPLACEMENTS_UNESCAPE.merge({
     ' ': '%20'
 });
 const URL_REPLACEMENTS_ESCAPE = Map([
+    [ ' ', '%20' ],
     [ '(', '%28' ],
     [ ')', '%29' ]
 ]);

--- a/test/to-markdown/images/escape-url-whitespace/output.md
+++ b/test/to-markdown/images/escape-url-whitespace/output.md
@@ -1,1 +1,1 @@
-![foo](/url Cool "title")
+![foo](/url%20Cool "title")

--- a/test/to-markdown/links/escape-href-whitespace/output.md
+++ b/test/to-markdown/links/escape-href-whitespace/output.md
@@ -1,1 +1,1 @@
-This is a [link](hello world.md)
+This is a [link](hello%20world.md)


### PR DESCRIPTION
GitHub doesn’t support whitespaces in markdown links. ([example gist](https://gist.github.com/SamyPesse/7fb520dabae059ff68ae1c4fa8551b3c)).

This PR fixes it.