### PR TITLE
Fix list without indentation

### DIFF
--- a/src/markdown/re/block.js
+++ b/src/markdown/re/block.js
@@ -30,7 +30,7 @@ const block = {
 };
 
 const _tag = '(?!(?:'
-    + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
+    + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code|li'
     + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
     + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:\\/|[^\\w\\s@]*@)\\b';
 

--- a/test/from-markdown/html/list-nested-without-indent/input.md
+++ b/test/from-markdown/html/list-nested-without-indent/input.md
@@ -1,0 +1,5 @@
+<ol>
+<li>
+<ol><li>Test</li></ol>
+</li>
+</ol>

--- a/test/from-markdown/html/list-nested-without-indent/output.yaml
+++ b/test/from-markdown/html/list-nested-without-indent/output.yaml
@@ -1,0 +1,30 @@
+document:
+  nodes:
+    - data: {}
+      kind: block
+      isVoid: false
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+          - kind: range
+            marks: []
+            text: ''
+        - data:
+            openingTag: "<ol>"
+            closingTag: "</ol>"
+            innerHtml: "\n<li>\n<ol><li>first item</li></ol>\n</li>\n"
+          kind: inline
+          isVoid: true
+          type: html
+          nodes:
+          - kind: text
+            ranges:
+            - kind: range
+              marks: []
+              text: " "
+        - kind: text
+          ranges:
+          - kind: range
+            marks: []
+            text: ''

--- a/test/from-markdown/html/list-without-indent/input.md
+++ b/test/from-markdown/html/list-without-indent/input.md
@@ -1,0 +1,3 @@
+<ol>
+<li>first item</li>
+</ol>

--- a/test/from-markdown/html/list-without-indent/output.yaml
+++ b/test/from-markdown/html/list-without-indent/output.yaml
@@ -1,0 +1,30 @@
+document:
+  nodes:
+    - data: {}
+      kind: block
+      isVoid: false
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+          - kind: range
+            marks: []
+            text: ''
+        - data:
+            openingTag: "<ol>"
+            closingTag: "</ol>"
+            innerHtml: "\n<li>first item</li>\n"
+          kind: inline
+          isVoid: true
+          type: html
+          nodes:
+          - kind: text
+            ranges:
+            - kind: range
+              marks: []
+              text: " "
+        - kind: text
+          ranges:
+          - kind: range
+            marks: []
+            text: ''

--- a/test/from-markdown/html/list/input.md
+++ b/test/from-markdown/html/list/input.md
@@ -1,0 +1,3 @@
+<ol>
+    <li>first item</li>
+</ol>

--- a/test/from-markdown/html/list/output.yaml
+++ b/test/from-markdown/html/list/output.yaml
@@ -1,0 +1,30 @@
+document:
+  nodes:
+    - data: {}
+      kind: block
+      isVoid: false
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+          - kind: range
+            marks: []
+            text: ''
+        - data:
+            openingTag: "<ol>"
+            closingTag: "</ol>"
+            innerHtml: "\n    <li>first item</li>\n"
+          kind: inline
+          isVoid: true
+          type: html
+          nodes:
+          - kind: text
+            ranges:
+            - kind: range
+              marks: []
+              text: " "
+        - kind: text
+          ranges:
+          - kind: range
+            marks: []
+            text: ''


### PR DESCRIPTION
This PR fixes parsing of a list without indentation

```
<ol>
<li>test</li>
</ol>
```

was different than
```
<ol>
   <li>test</li>
</ol>
```
