### PR TITLE
Parse HTML blocks

### DIFF
--- a/src/markdown/blocks/html.js
+++ b/src/markdown/blocks/html.js
@@ -1,0 +1,36 @@
+const { Serializer, Deserializer, Block, BLOCKS } = require('../../');
+const reBlock = require('../re/block');
+
+/**
+ * Serialize an HR to markdown
+ * @type {Serializer}
+ */
+const serialize = Serializer()
+    .matchType(BLOCKS.HTML)
+    .then((state) => {
+        const node = state.peek();
+        const { data } = node;
+
+        return state
+            .shift()
+            .write(`${data.get('html').trim()}\n\n`);
+    });
+
+/**
+ * Deserialize an HTML block to a node.
+ * @type {Deserializer}
+ */
+const deserialize = Deserializer()
+    .matchRegExp(reBlock.html, (state, match) => {
+        const node = Block.create({
+            type: BLOCKS.HTML,
+            isVoid: true,
+            data: {
+                html: match[0]
+            }
+        });
+
+        return state.push(node);
+    });
+
+module.exports = { serialize, deserialize };

--- a/src/markdown/blocks/index.js
+++ b/src/markdown/blocks/index.js
@@ -10,9 +10,11 @@ const list = require('./list');
 const definition = require('./definition');
 const math = require('./math');
 const comment = require('./comment');
+const html = require('./html');
 const custom = require('./custom');
 
 module.exports = [
+    html,
     definition,
     table,
     hr,

--- a/src/markdown/re/block.js
+++ b/src/markdown/re/block.js
@@ -8,7 +8,7 @@ const block = {
     code:       /^((?: {4}|\t)[^\n]+\n*)+/,
     hr:         /^( *[-*_]){3,} *(?:\n|$)/,
     blockquote: /^( *>[^\n]+(\n(?!def)[^\n]+)*\n*)+/,
-    // html:       /^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,
+    html:       /^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,
     def:        /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n|$)/,
     footnote:   /^\[\^([^\]]+)\]: ([^\n]+)/,
     paragraph:  /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def|math|comment|customBlock|table|tablenp))+)\n*/,
@@ -44,7 +44,7 @@ block.list.block_ul = replace(block.list.block)(/bullet/g, block.list.bullet_ul)
 block.list.block_ol = replace(block.list.block)(/bullet/g, block.list.bullet_ol)();
 block.list.block = replace(block.list.block)(/bullet/g, block.list.bullet)();
 
-// block.html = replace(block.html)('comment', /<!--[\s\S]*?-->/)('closed', /<(tag)[\s\S]+?<\/\1>/)('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)(/tag/g, _tag)();
+block.html = replace(block.html)('comment', /<!--[\s\S]*?-->/)('closed', /<(tag)[\s\S]+?<\/\1>/)('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)(/tag/g, _tag)();
 
 block.paragraph = replace(block.paragraph)
     ('hr', block.hr)

--- a/test/from-markdown/html/block-ul/input.md
+++ b/test/from-markdown/html/block-ul/input.md
@@ -1,0 +1,12 @@
+<ol>
+<li>test</li>
+</ol>
+
+Hello
+
+<ol>
+    <li>test</li>
+</ol>
+
+
+World

--- a/test/from-markdown/html/block-ul/output.yaml
+++ b/test/from-markdown/html/block-ul/output.yaml
@@ -2,19 +2,12 @@ document:
   data: {}
   kind: document
   nodes:
-    - data: {}
-      kind: block
-      isVoid: false
-      type: paragraph
-      nodes:
-        - kind: text
-          ranges:
-            - kind: range
-              marks: []
-              text: This is a paragraph followed by an HTML comment.
     - data:
-        html: |
-          <!-- This is an HTML comment -->
+        html: |+
+          <ol>
+          <li>test</li>
+          </ol>
+
       kind: block
       isVoid: true
       type: html_block
@@ -33,4 +26,30 @@ document:
           ranges:
             - kind: range
               marks: []
-              text: And here goes another paragraph.
+              text: Hello
+    - data:
+        html: |+
+          <ol>
+              <li>test</li>
+          </ol>
+
+
+      kind: block
+      isVoid: true
+      type: html_block
+      nodes:
+        - kind: text
+          ranges:
+            - kind: range
+              marks: []
+              text: ' '
+    - data: {}
+      kind: block
+      isVoid: false
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+            - kind: range
+              marks: []
+              text: World

--- a/test/from-markdown/html/empty-tag/output.yaml
+++ b/test/from-markdown/html/empty-tag/output.yaml
@@ -1,22 +1,17 @@
 document:
+  data: {}
+  kind: document
   nodes:
-    - kind: block
-      type: paragraph
+    - data:
+        html: >
+          <iframe src="src" frameborder="0" width="960" height="569"
+          allowfullscreen mozallowfullscreen webkitallowfullscreen></iframe>
+      kind: block
+      isVoid: true
+      type: html_block
       nodes:
         - kind: text
           ranges:
-            - text: ''
-        - kind: inline
-          type: html
-          isVoid: true
-          data:
-            openingTag: '<iframe src="src" frameborder="0" width="960" height="569" allowfullscreen mozallowfullscreen webkitallowfullscreen>'
-            innerHtml: ''
-            closingTag: '</iframe>'
-          nodes:
-            - kind: text
-              ranges:
-                - text: ' '
-        - kind: text
-          ranges:
-            - text: ''
+            - kind: range
+              marks: []
+              text: ' '

--- a/test/from-markdown/html/p-not-merged/input.md
+++ b/test/from-markdown/html/p-not-merged/input.md
@@ -1,1 +1,1 @@
-<p>Hello</p> World <p>!</p>
+<p>Hello</p> W**or**ld <p>!</p>

--- a/test/from-markdown/html/p-not-merged/output.yaml
+++ b/test/from-markdown/html/p-not-merged/output.yaml
@@ -1,28 +1,18 @@
+# Same result in GitHub
+# https://gist.github.com/SamyPesse/e808e6313892964e341290c2048a9d5c
 document:
+  data: {}
+  kind: document
   nodes:
-    - kind: block
-      type: paragraph
+    - data:
+        html: |
+          <p>Hello</p> W**or**ld <p>!</p>
+      kind: block
+      isVoid: true
+      type: html_block
       nodes:
         - kind: text
           ranges:
-            - text: ''
-        - kind: inline
-          isVoid: true
-          type: html
-          data:
-            openingTag: <p>
-            innerHtml: Hello
-            closingTag: </p>
-        - kind: text
-          ranges:
-            - text: ' World '
-        - kind: inline
-          isVoid: true
-          type: html
-          data:
-            openingTag: <p>
-            innerHtml: '!'
-            closingTag: </p>
-        - kind: text
-          ranges:
-            - text: ''
+            - kind: range
+              marks: []
+              text: ' '

--- a/test/from-markdown/html/p/output.yaml
+++ b/test/from-markdown/html/p/output.yaml
@@ -1,18 +1,16 @@
 document:
+  data: {}
+  kind: document
   nodes:
-    - kind: block
-      type: paragraph
+    - data:
+        html: |
+          <p>Hello <a href="https://www.google.com">World</a> !</p>
+      kind: block
+      isVoid: true
+      type: html_block
       nodes:
         - kind: text
           ranges:
-            - text: ''
-        - kind: inline
-          isVoid: true
-          type: html
-          data:
-            openingTag: '<p>'
-            innerHtml: 'Hello <a href="https://www.google.com">World</a> !'
-            closingTag: '</p>'
-        - kind: text
-          ranges:
-            - text: ''
+            - kind: range
+              marks: []
+              text: ' '


### PR DESCRIPTION
This PR adds back the parsing of HTML blocks. This PR fixes #92.

I'm not sure why `markup-it` and `marked` were not using this `block.html` :/

All tests are passing, and I've added more tests.