### PR TITLE
Fix link reference parsing after HTML

### DIFF
--- a/src/markdown/blocks/index.js
+++ b/src/markdown/blocks/index.js
@@ -14,8 +14,10 @@ const html = require('./html');
 const custom = require('./custom');
 
 module.exports = [
-    html,
+    // All link definition (for link reference) must be resolved first.
     definition,
+    // HTML must be high in the stack too.
+    html,
     table,
     hr,
     list,

--- a/test/from-markdown/links/reference-with-html/input.md
+++ b/test/from-markdown/links/reference-with-html/input.md
@@ -1,0 +1,6 @@
+<h1><p align="center"><a href="https://neutrino.js.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
+
+[![NPM version][npm-image]][npm-url]
+
+[npm-image]: https://img.shields.io/npm/v/neutrino.svg
+[npm-url]: https://npmjs.org/package/neutrino

--- a/test/from-markdown/links/reference-with-html/output.yaml
+++ b/test/from-markdown/links/reference-with-html/output.yaml
@@ -1,0 +1,8 @@
+document:
+  nodes:
+    - kind: block
+      type: paragraph
+      nodes:
+        - kind: text
+          ranges:
+            - text: ''

--- a/test/from-markdown/links/reference-with-html/output.yaml
+++ b/test/from-markdown/links/reference-with-html/output.yaml
@@ -1,8 +1,60 @@
 document:
+  data: {}
+  kind: document
   nodes:
-    - kind: block
+    - data:
+        html: >-
+          <h1><p align="center"><a href="https://neutrino.js.org"><img
+          src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png"
+          height="150"></a></p></h1>
+      kind: block
+      isVoid: true
+      type: html_block
+      nodes:
+        - kind: text
+          ranges:
+            - kind: range
+              marks: []
+              text: ' '
+    - data: {}
+      kind: block
+      isVoid: false
       type: paragraph
       nodes:
         - kind: text
           ranges:
-            - text: ''
+            - kind: range
+              marks: []
+              text: ''
+        - data:
+            href: 'https://npmjs.org/package/neutrino'
+          kind: inline
+          isVoid: false
+          type: link
+          nodes:
+            - kind: text
+              ranges:
+                - kind: range
+                  marks: []
+                  text: ''
+            - data:
+                src: 'https://img.shields.io/npm/v/neutrino.svg'
+              kind: inline
+              isVoid: true
+              type: image
+              nodes:
+                - kind: text
+                  ranges:
+                    - kind: range
+                      marks: []
+                      text: ' '
+            - kind: text
+              ranges:
+                - kind: range
+                  marks: []
+                  text: ''
+        - kind: text
+          ranges:
+            - kind: range
+              marks: []
+              text: ''


### PR DESCRIPTION
Fix #97 

Reference definitions at the end of the document were not parsed yet when we encountered the first links