### PR TITLE
Fix decoding of HTML entities (emojis)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   "dependencies": {
     "asciidoctor.js": "^1.5.5-4",
     "detect-newline": "^2.1.0",
+    "entities": "^1.1.1",
     "escape-string-regexp": "^1.0.5",
     "front-matter": "^2.1.2",
-    "html-entities": "1.2.0",
     "htmlclean": "^2.7.8",
     "htmlparser2": "3.9.2",
     "indent-string": "2.1.0",

--- a/src/asciidoc/inlines/escape.js
+++ b/src/asciidoc/inlines/escape.js
@@ -1,9 +1,7 @@
-const entities = require('html-entities');
+const entities = require('entities');
 const { Map } = require('immutable');
 const { Serializer, MARKS } = require('../../');
 const { escapeWith } = require('../../utils/escape');
-
-const xmlEntities = new entities.XmlEntities();
 
 // Replacements for Asciidoc escaping
 const REPLACEMENTS = Map([
@@ -29,7 +27,7 @@ const REPLACEMENTS = Map([
  */
 function escape(text) {
     text = escapeWith(REPLACEMENTS, text);
-    return xmlEntities.encode(text);
+    return entities.encodeXML(text);
 }
 
 /**

--- a/src/html/escape.js
+++ b/src/html/escape.js
@@ -1,5 +1,4 @@
-const entities = require('html-entities');
-const htmlEntities = new entities.AllHtmlEntities();
+const entities = require('entities');
 
 /**
  * Escape all entities (HTML + XML)
@@ -7,7 +6,7 @@ const htmlEntities = new entities.AllHtmlEntities();
  * @return {String}
  */
 function escape(str) {
-    return htmlEntities.encode(str);
+    return entities.encodeXML(str);
 }
 
 module.exports = escape;

--- a/src/html/unescape.js
+++ b/src/html/unescape.js
@@ -1,5 +1,4 @@
-const entities = require('html-entities');
-const htmlEntities = new entities.AllHtmlEntities();
+const entities = require('entities');
 
 /**
  * Unescape all entities (HTML + XML)
@@ -7,7 +6,10 @@ const htmlEntities = new entities.AllHtmlEntities();
  * @return {String}
  */
 function unescape(str) {
-    return htmlEntities.decode(str);
+    str = entities.decodeXML(str);
+    str = entities.decodeHTML(str);
+
+    return str;
 }
 
 module.exports = unescape;

--- a/src/html/unescape.js
+++ b/src/html/unescape.js
@@ -6,7 +6,6 @@ const entities = require('entities');
  * @return {String}
  */
 function unescape(str) {
-    str = entities.decodeXML(str);
     str = entities.decodeHTML(str);
 
     return str;

--- a/src/markdown/utils.js
+++ b/src/markdown/utils.js
@@ -1,9 +1,6 @@
 const { Map } = require('immutable');
-const entities = require('html-entities');
+const entities = require('entities');
 const { escapeWith, unescapeWith } = require('../utils/escape');
-
-const htmlEntities = new entities.AllHtmlEntities();
-const xmlEntities = new entities.XmlEntities();
 
 // Replacements for Markdown escaping
 // See http://spec.commonmark.org/0.15/#backslash-escapes
@@ -48,7 +45,7 @@ const URL_REPLACEMENTS_ESCAPE = Map([
  */
 function escapeMarkdown(str, escapeXML) {
     str = escapeWith(REPLACEMENTS_ESCAPE, str);
-    return escapeXML === false ? str : xmlEntities.encode(str);
+    return escapeXML === false ? str : entities.encodeXML(str);
 }
 
 /**
@@ -60,7 +57,10 @@ function escapeMarkdown(str, escapeXML) {
  */
 function unescapeMarkdown(str) {
     str = unescapeWith(REPLACEMENTS_UNESCAPE, str);
-    return htmlEntities.decode(str);
+    str = entities.decodeXML(str);
+    str = entities.decodeHTML(str);
+
+    return str;
 }
 
 /**

--- a/src/markdown/utils.js
+++ b/src/markdown/utils.js
@@ -57,7 +57,6 @@ function escapeMarkdown(str, escapeXML) {
  */
 function unescapeMarkdown(str) {
     str = unescapeWith(REPLACEMENTS_UNESCAPE, str);
-    str = entities.decodeXML(str);
     str = entities.decodeHTML(str);
 
     return str;

--- a/test/from-html/entities/input.html
+++ b/test/from-html/entities/input.html
@@ -1,0 +1,3 @@
+<body>
+    <p>Hello world &#128268;</p>
+</body>

--- a/test/from-html/entities/output.yaml
+++ b/test/from-html/entities/output.yaml
@@ -1,0 +1,8 @@
+document:
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: 'Hello world 🔌'

--- a/test/from-markdown/html/entities-char/input.md
+++ b/test/from-markdown/html/entities-char/input.md
@@ -1,0 +1,1 @@
+Hello world &#128268;

--- a/test/from-markdown/html/entities-char/output.yaml
+++ b/test/from-markdown/html/entities-char/output.yaml
@@ -1,0 +1,12 @@
+document:
+  data: {}
+  object: document
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - object: leaf
+              marks: []
+              text: 'Hello world 🔌'

--- a/test/to-markdown/text-escaping/emojis/input.yaml
+++ b/test/to-markdown/text-escaping/emojis/input.yaml
@@ -1,0 +1,8 @@
+document:
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: Hello World 🚀

--- a/test/to-markdown/text-escaping/emojis/output.md
+++ b/test/to-markdown/text-escaping/emojis/output.md
@@ -1,0 +1,1 @@
+Hello World 🚀

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,10 +1659,6 @@ hosted-git-info@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
 
-html-entities:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
-
 htmlclean@^2.7.8:
   version "2.7.8"
   resolved "https://registry.yarnpkg.com/htmlclean/-/htmlclean-2.7.8.tgz#49bd3b9416297aaf6a8d25b43d5ac10d16919033"


### PR DESCRIPTION
This PR fixes the decoding of emojis and other HTML entities when parsing HTML or Markdown.

It uses [`entities`](https://yarnpkg.com/en/package/entities) instead of [`html-entities`](https://yarnpkg.com/en/package/html-entities) because it doesn't support emojis: https://github.com/mdevils/node-html-entities/pull/18