### PR TITLE
Fix [def] parsing for code blocks in list

### DIFF
--- a/test/from-markdown/code-blocks/in-list/input.md
+++ b/test/from-markdown/code-blocks/in-list/input.md
@@ -1,7 +1,5 @@
 1. Here's some code:
 
    ```
-   const foo = {
-       [bar]: 'bar'
-   };
+   [bar]: 'bar'
    ```

--- a/test/from-markdown/code-blocks/in-list/output.yaml
+++ b/test/from-markdown/code-blocks/in-list/output.yaml
@@ -23,18 +23,4 @@ document:
                     - object: text
                       leaves:
                         - object: leaf
-                          text: 'const foo = {'
-                - object: block
-                  type: code_line
-                  nodes:
-                    - object: text
-                      leaves:
-                        - object: leaf
-                          text: '    [bar]: ''bar'''
-                - object: block
-                  type: code_line
-                  nodes:
-                    - object: text
-                      leaves:
-                        - object: leaf
-                          text: '};'
+                          text: '[bar]: ''bar'''

--- a/test/to-markdown/code-blocks/in-list/input.yaml
+++ b/test/to-markdown/code-blocks/in-list/input.yaml
@@ -14,27 +14,10 @@ document:
                   leaves:
                     - object: leaf
                       text: 'Here''s some code:'
-            - object: block
-              type: code_block
-              nodes:
                 - object: block
                   type: code_line
                   nodes:
                     - object: text
                       leaves:
                         - object: leaf
-                          text: 'const foo = {'
-                - object: block
-                  type: code_line
-                  nodes:
-                    - object: text
-                      leaves:
-                        - object: leaf
-                          text: '    [bar]: ''bar'''
-                - object: block
-                  type: code_line
-                  nodes:
-                    - object: text
-                      leaves:
-                        - object: leaf
-                          text: '};'
+                          text: '[bar]: ''bar'''

--- a/test/to-markdown/code-blocks/in-list/output.md
+++ b/test/to-markdown/code-blocks/in-list/output.md
@@ -1,7 +1,5 @@
 1. Here's some code:
 
    ```
-   const foo = {
-       [bar]: 'bar'
-   };
+   [bar]: 'bar'
    ```


### PR DESCRIPTION
Although #106 makes def parsing more standard and fixes parsing for a vast majority of use cases, it's not perfect. This PR changes the test case to make the error missing part surface.