### PR TITLE
Fix marks serialization when starting/ending with a space

### DIFF
--- a/src/markdown/inlines/bold.js
+++ b/src/markdown/inlines/bold.js
@@ -1,5 +1,6 @@
 const { Serializer, Deserializer, Mark, MARKS } = require('../../');
 const reInline = require('../re/inline');
+const utils = require('../utils');
 
 /**
  * Serialize a bold text to markdown
@@ -7,7 +8,7 @@ const reInline = require('../re/inline');
  */
 const serialize = Serializer()
     .transformMarkedLeaf(MARKS.BOLD, (state, text, mark) => {
-        return `**${text}**`;
+        return utils.wrapInline(text, '**');
     });
 
 /**

--- a/src/markdown/inlines/code.js
+++ b/src/markdown/inlines/code.js
@@ -1,5 +1,6 @@
 const { Serializer, Deserializer, Mark, Text, MARKS } = require('../../');
 const reInline = require('../re/inline');
+const utils = require('../utils');
 
 /**
  * Serialize a code text to markdown
@@ -14,7 +15,7 @@ const serialize = Serializer()
             separator += '`';
         }
 
-        return (separator + text + separator);
+        return utils.wrapInline(text, separator);
     });
 
 /**

--- a/src/markdown/inlines/italic.js
+++ b/src/markdown/inlines/italic.js
@@ -1,5 +1,6 @@
 const { Serializer, Deserializer, Mark, MARKS } = require('../../');
 const reInline = require('../re/inline');
+const utils = require('../utils');
 
 /**
  * Serialize a italic text to markdown
@@ -7,7 +8,7 @@ const reInline = require('../re/inline');
  */
 const serialize = Serializer()
     .transformMarkedLeaf(MARKS.ITALIC, (state, text) => {
-        return `_${text}_`;
+        return utils.wrapInline(text, '_');
     });
 
 /**

--- a/src/markdown/inlines/strikethrough.js
+++ b/src/markdown/inlines/strikethrough.js
@@ -1,5 +1,6 @@
 const { Serializer, Deserializer, Mark, MARKS } = require('../../');
 const reInline = require('../re/inline');
+const utils = require('../utils');
 
 /**
  * Serialize a strikethrough text to markdown
@@ -7,7 +8,7 @@ const reInline = require('../re/inline');
  */
 const serialize = Serializer()
     .transformMarkedLeaf(MARKS.STRIKETHROUGH, (state, text) => {
-        return `~~${text}~~`;
+        return utils.wrapInline(text, '~~');
     });
 
 /**

--- a/src/markdown/utils.js
+++ b/src/markdown/utils.js
@@ -134,6 +134,18 @@ function resolveRef(state, refID) {
     return Map(data).filter(Boolean);
 }
 
+/**
+ * Wrap inline content with the provided characters.
+ * e.g wrapInline('bold content', '**')
+ * @param {String} str
+ * @param {String} chars
+ */
+function wrapInline(str, chars) {
+    return str
+        .replace(/^\s*/, spaces => `${spaces}${chars}`)
+        .replace(/\s*$/, spaces => `${chars}${spaces}`);
+}
+
 module.exports = {
     escape: escapeMarkdown,
     unescape: unescapeMarkdown,
@@ -142,5 +154,7 @@ module.exports = {
     unescapeURL,
 
     replace,
-    resolveRef
+    resolveRef,
+
+    wrapInline
 };

--- a/test/to-markdown/marks/bold-whitespace/input.yaml
+++ b/test/to-markdown/marks/bold-whitespace/input.yaml
@@ -5,7 +5,7 @@ document:
       nodes:
         - object: text
           leaves:
-            - text: '- Hello'
+            - text: 'Hello'
               marks: []
             - text: ' World'
               marks:
@@ -17,7 +17,7 @@ document:
                 - type: BOLD
             - text: 'you? '
               marks: []
-            - text: "World\n"
+            - text: "World:\n"
               marks:
                 - type: BOLD
             - text: 'Fine, thanks!'

--- a/test/to-markdown/marks/bold-whitespace/input.yaml
+++ b/test/to-markdown/marks/bold-whitespace/input.yaml
@@ -1,0 +1,24 @@
+document:
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: '- Hello'
+              marks: []
+            - text: ' World'
+              marks:
+                - type: BOLD
+            - text: '! How '
+              marks: []
+            - text: 'are '
+              marks:
+                - type: BOLD
+            - text: 'you? '
+              marks: []
+            - text: "World\n"
+              marks:
+                - type: BOLD
+            - text: 'Fine, thanks!'
+              marks: []

--- a/test/to-markdown/marks/bold-whitespace/output.md
+++ b/test/to-markdown/marks/bold-whitespace/output.md
@@ -1,2 +1,2 @@
-Hello **World**! How **are** you? **World:**
+Hello **World**! How **are** you? **World:**  
 Fine, thanks!

--- a/test/to-markdown/marks/bold-whitespace/output.md
+++ b/test/to-markdown/marks/bold-whitespace/output.md
@@ -1,0 +1,2 @@
+Hello **World**! How **are** you? **World:**
+Fine, thanks!

--- a/test/to-markdown/marks/code-whitespace/input.yaml
+++ b/test/to-markdown/marks/code-whitespace/input.yaml
@@ -1,0 +1,13 @@
+document:
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: 'Hello'
+              marks: []
+            - text: ' World '
+              marks:
+                - type: CODE
+            - text: '!'

--- a/test/to-markdown/marks/code-whitespace/output.md
+++ b/test/to-markdown/marks/code-whitespace/output.md
@@ -1,0 +1,1 @@
+Hello `World` !

--- a/test/to-markdown/marks/italic-whitespace/input.yaml
+++ b/test/to-markdown/marks/italic-whitespace/input.yaml
@@ -1,0 +1,12 @@
+document:
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: Hello
+              marks: []
+            - text: ' World '
+              marks:
+                - type: ITALIC

--- a/test/to-markdown/marks/italic-whitespace/output.md
+++ b/test/to-markdown/marks/italic-whitespace/output.md
@@ -1,0 +1,1 @@
+Hello _World_ 

--- a/test/to-markdown/marks/strikethrough-whitespace/input.yaml
+++ b/test/to-markdown/marks/strikethrough-whitespace/input.yaml
@@ -1,0 +1,12 @@
+document:
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: Hello
+              marks: []
+            - text: ' World '
+              marks:
+                - type: STRIKETHROUGH

--- a/test/to-markdown/marks/strikethrough-whitespace/output.md
+++ b/test/to-markdown/marks/strikethrough-whitespace/output.md
@@ -1,0 +1,1 @@
+Hello ~~World~~ 


### PR DESCRIPTION
The following Slate document:

```
Some <bold>text </bold>content.
```

is currently serialized as:

```
Some **text **content.
```

Which is not valid markdown (doesn't work on GitHub for example). It should be:

```
Some **text** content.
```

We need to keep mind that it may start/end with 1+ white space, or a line break, etc.