### PR TITLE
Add test for multi-lines HTML comments

### DIFF
--- a/test/from-markdown/html/comment-multi-lines/input.md
+++ b/test/from-markdown/html/comment-multi-lines/input.md
@@ -1,0 +1,7 @@
+This is a paragraph followed by an HTML comment.
+
+<!-- This is a
+# multi-line comment
+## starting with heading -->
+
+And here goes another paragraph.

--- a/test/from-markdown/html/comment-multi-lines/output.yaml
+++ b/test/from-markdown/html/comment-multi-lines/output.yaml
@@ -1,0 +1,38 @@
+document:
+  data: {}
+  object: document
+  nodes:
+    - data: {}
+      object: block
+      isVoid: false
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - object: leaf
+              marks: []
+              text: This is a paragraph followed by an HTML comment.
+    - data:
+        html:  |-
+            <!-- This is a
+            # multi-line comment
+            ## starting with heading -->
+      object: block
+      isVoid: true
+      type: html_block
+      nodes:
+        - object: text
+          leaves:
+            - object: leaf
+              marks: []
+              text: ''
+    - data: {}
+      object: block
+      isVoid: false
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - object: leaf
+              marks: []
+              text: And here goes another paragraph.


### PR DESCRIPTION
This PR adds a test (that passed) for multi-lines HTML comments in Markdown.

It follows a support ticket on GitBook.