### PR TITLE
Fix line breaks serialization in list items

### DIFF
--- a/test/to-markdown/lists/list-item-line-breaks/input.yaml
+++ b/test/to-markdown/lists/list-item-line-breaks/input.yaml
@@ -1,0 +1,14 @@
+document:
+  nodes:
+    - object: block
+      type: ordered_list
+      nodes:
+        - object: block
+          type: list_item
+          nodes:
+            - object: block
+              type: unstyled
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Hello\nWorld"

--- a/test/to-markdown/lists/list-item-line-breaks/output.md
+++ b/test/to-markdown/lists/list-item-line-breaks/output.md
@@ -1,0 +1,2 @@
+1. Hello  
+ World


### PR DESCRIPTION
Right now, line breaks in list items are not properly serialized. The following document:

```
<ul>
	<li>Hello\nWorld</li>
</ul>
```

Is serialized to:

```
* Hello World
```

Which is not rendered as a line-break nor will it be parsed as such so the line break is lost. The way line-breaks are treated in list items is a bit complex so we'd need to add more tests and maybe tweak the one that's currenly added. The specification can be found here:

* [List Items Spec](https://spec.commonmark.org/0.28/#list-items)