### PR TITLE
Fix inline code with liquid syntax

### DIFF
--- a/test/from-markdown/marks/code/liquid/input.md
+++ b/test/from-markdown/marks/code/liquid/input.md
@@ -1,0 +1,1 @@
+This is `{% someContent %}` after

--- a/test/from-markdown/marks/code/liquid/output.yaml
+++ b/test/from-markdown/marks/code/liquid/output.yaml
@@ -1,0 +1,12 @@
+document:
+  nodes:
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: 'This is'
+            - text: "{% someContent %}"
+              marks:
+                - type: CODE
+            - text: ' after'


### PR DESCRIPTION
Liquid tags in inlide-code are not correctly parsed

![image](https://user-images.githubusercontent.com/5053593/40620387-f28437a8-6298-11e8-8b6d-220118f86b7d.png)
