### PR TITLE
Fix slashes escaping in data properties

### DIFF
--- a/src/markdown/liquid/escape.js
+++ b/src/markdown/liquid/escape.js
@@ -1,8 +1,9 @@
-const { Map } = require('immutable');
+const { OrderedMap } = require('immutable');
 const { escapeWith, unescapeWith } = require('../../utils/escape');
 
 // Replacements for properties escapement
-const REPLACEMENTS = Map([
+const REPLACEMENTS = OrderedMap([
+    [ '\\', '\\\\' ],
     [ '*', '\\*' ],
     [ '#', '\\#' ],
     [ '(', '\\(' ],
@@ -18,5 +19,9 @@ const REPLACEMENTS = Map([
 
 module.exports = {
     escape:   (str) => escapeWith(REPLACEMENTS, str),
-    unescape: (str) => unescapeWith(REPLACEMENTS, str)
+
+    // User-inserted slashes have to be escaped first.
+    // But they need to be unescaped last as markupit adds slashes itself.
+    // So first we unescape the slashes combined with something else and end by unescaping the lone-slashes.
+    unescape: (str) => unescapeWith(REPLACEMENTS.reverse(), str)
 };

--- a/test/from-markdown/custom-blocks/data-html/input.md
+++ b/test/from-markdown/custom-blocks/data-html/input.md
@@ -1,0 +1,1 @@
+{% embed json="{\"html\":\"<div style=\\\"background-color: red;\\\" />\"}" %}

--- a/test/from-markdown/custom-blocks/data-html/output.yaml
+++ b/test/from-markdown/custom-blocks/data-html/output.yaml
@@ -1,0 +1,7 @@
+document:
+  nodes:
+    - object: block
+      type: x-embed
+      isVoid: true
+      data:
+        json: '{"html":"<div style=\"background-color: red;\" />"}'

--- a/test/to-markdown/custom-blocks/data-html/input.yaml
+++ b/test/to-markdown/custom-blocks/data-html/input.yaml
@@ -1,0 +1,7 @@
+document:
+  nodes:
+    - object: block
+      type: x-embed
+      isVoid: true
+      data:
+        json: '{"html":"<div style=\"background-color: red;\" />"}'

--- a/test/to-markdown/custom-blocks/data-html/output.md
+++ b/test/to-markdown/custom-blocks/data-html/output.md
@@ -1,0 +1,1 @@
+{% embed json="{\"html\":\"<div style=\\\"background-color: red;\\\" />\"}" %}


### PR DESCRIPTION
This bug has been reported in GitBook. Embeds have JSON in their data property so we end up with something like:

```
<embed data={{ html: '<div style="background-color: red;" />' }} />
```

It's serialized to:

```
{% embed data="{ \"html\": \"<div style=\\"background-color: red;\\" />\" }" %}
```

Which leads to an invalid JSON string, the expected result is:

```
{% embed data="{ \"html\": \"<div style=\\\"background-color: red;\\\" />\" }" %}
```