### PR TITLE
Supports blocks in table cells

### DIFF
--- a/src/markdown/blocks/table.js
+++ b/src/markdown/blocks/table.js
@@ -104,11 +104,16 @@ function parseRow(state, row) {
     // Tokenize each cell
     const cellNodes = cells.map(cell => {
         const text = cell.trim();
-        const nodes = state.use('inline').deserialize(text); // state.deserializeWith(text, rowRules);
+        const nodes = state.use('inline').deserialize(text);
+
+        const paragraph = Block.create({
+            type: BLOCKS.PARAGRAPH,
+            nodes
+        });
 
         return Block.create({
             type: BLOCKS.TABLE_CELL,
-            nodes
+            nodes: [ paragraph ]
         });
     });
 


### PR DESCRIPTION
Currently the modeling for table specifies that cells contain texts & inlines. In GitBook.com, we've already built a normalization to wrap these text/inlines in a paragraph.

# Data modeling

In `markup-it` (before this PR):

```yaml
- type: table
  kind: block
  nodes:
    - type: table-row
      kind: block
      nodes:
        - type: table-cell
          kind: block
          nodes:
            - kind: text
              text: Hello
```

With this PR (and already in GitBook.com):

```yaml
- type: table
  kind: block
  nodes:
    - type: table-row
      kind: block
      nodes:
        - type: table-cell
          kind: block
          nodes:
            - kind: block
              type: paragraph
              nodes:
                - kind: text
                  text: Hello
```

# Markdown serialization

### Solution 1: `<br />`

In GitHub, you can use `<br />` to insert newlines in table cells:

```markdown
| A | B |
| - | - |
| a | b<br/>c |
```

But it doesn't support inserting lists or quotes in cells. This solution could work if we decide to only allow multiple paragraphs in cells (no lists, etc).

### Solution 2: serialize complex tables to HTML

Another solution may be for tables with cells containing more than one paragraph to serialize it as HTML instead of Markdown tables.

It'll make the markup more complex for people editing the markdown afterward. 

### Solution 3: output using a custom table syntax

For example:

```markdown
| A | B |
| - | - |
| a | b |
|   | c |
| - | - |
| d | e |
```

But it'll not work on GitHub...