### PR TITLE
Rename align to aligns

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Unreleased
 
+- Rename table aligns data from `align` to `aligns`
+
 ### 8.1.3
 
 - Remove warnings when using Slate 0.34.x

--- a/src/html/blocks/table.js
+++ b/src/html/blocks/table.js
@@ -1,7 +1,7 @@
 const { Serializer, BLOCKS } = require('../../');
 
-// Key to store the current table align in the state
-const ALIGN = 'current_table_align';
+// Key to store the current table aligns in the state
+const ALIGNS = 'current_table_aligns';
 
 // Key to indicate that the current row is a header
 const THEAD = 'next_row_is_header';
@@ -18,17 +18,17 @@ const table = {
         .matchType(BLOCKS.TABLE)
         .then(state => {
             const tableNode = state.peek();
-            const align = tableNode.data.get('align');
+            const aligns = tableNode.data.get('aligns');
             const rows = tableNode.nodes;
 
             const headerText = state
-                      .setProp(ALIGN, align)
+                      .setProp(ALIGNS, aligns)
                       .setProp(COL, 0)
                       .setProp(THEAD, true)
                       .serialize(rows.slice(0, 1));
 
             const bodyText = state
-                      .setProp(ALIGN, align)
+                      .setProp(ALIGNS, aligns)
                       .setProp(COL, 0)
                       .serialize(rows.rest());
 
@@ -75,9 +75,9 @@ const cell = {
         .then(state => {
             const node = state.peek();
             const isHead = state.getProp(THEAD);
-            const align = state.getProp(ALIGN);
+            const aligns = state.getProp(ALIGNS);
             const column = state.getProp(COL);
-            const cellAlign = align[column];
+            const cellAlign = aligns[column];
 
             const inner = state.serialize(node.nodes);
 

--- a/test/from-markdown/tables/align-center/output.yaml
+++ b/test/from-markdown/tables/align-center/output.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - center
           - null
       nodes:

--- a/test/from-markdown/tables/align-left/output.yaml
+++ b/test/from-markdown/tables/align-left/output.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - left
           - null
       nodes:

--- a/test/from-markdown/tables/align-right/output.yaml
+++ b/test/from-markdown/tables/align-right/output.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - right
           - null
       nodes:

--- a/test/from-markdown/tables/following-paragraph/output.yaml
+++ b/test/from-markdown/tables/following-paragraph/output.yaml
@@ -9,7 +9,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:

--- a/test/from-markdown/tables/gfm/output.yaml
+++ b/test/from-markdown/tables/gfm/output.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:

--- a/test/from-markdown/tables/normal/output.yaml
+++ b/test/from-markdown/tables/normal/output.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:

--- a/test/from-markdown/tables/with-marks/output.yaml
+++ b/test/from-markdown/tables/with-marks/output.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:

--- a/test/to-html/tables/align-center/input.yaml
+++ b/test/to-html/tables/align-center/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - center
           - null
       nodes:

--- a/test/to-html/tables/align-left/input.yaml
+++ b/test/to-html/tables/align-left/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - left
           - null
       nodes:

--- a/test/to-html/tables/align-right/input.yaml
+++ b/test/to-html/tables/align-right/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - right
           - null
       nodes:

--- a/test/to-html/tables/normal/input.yaml
+++ b/test/to-html/tables/normal/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:

--- a/test/to-markdown/lists/ul-loose-with-random-stuff/input.yaml
+++ b/test/to-markdown/lists/ul-loose-with-random-stuff/input.yaml
@@ -21,7 +21,7 @@ document:
             - object: block
               type: table
               data:
-                align:
+                aligns:
                   - right
                   - null
               nodes:

--- a/test/to-markdown/table/align-center/input.yaml
+++ b/test/to-markdown/table/align-center/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - center
           - null
       nodes:

--- a/test/to-markdown/table/align-left/input.yaml
+++ b/test/to-markdown/table/align-left/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - left
           - null
       nodes:

--- a/test/to-markdown/table/align-right/input.yaml
+++ b/test/to-markdown/table/align-right/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - right
           - null
       nodes:

--- a/test/to-markdown/table/follow-heading/input.yaml
+++ b/test/to-markdown/table/follow-heading/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:

--- a/test/to-markdown/table/normal/input.yaml
+++ b/test/to-markdown/table/normal/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:

--- a/test/to-markdown/table/with-marks/input.yaml
+++ b/test/to-markdown/table/with-marks/input.yaml
@@ -3,7 +3,7 @@ document:
     - object: block
       type: table
       data:
-        align:
+        aligns:
           - null
           - null
       nodes:


### PR DESCRIPTION
This PR just rename table `align` data to `aligns`, because it's clearer that it's the aligns for every cell, and not the align of the table itself.