### PR TITLE
Serialize headings id using HTML

### DIFF
--- a/src/markdown/blocks/heading.js
+++ b/src/markdown/blocks/heading.js
@@ -25,7 +25,7 @@ const serialize = Serializer()
 
         let inner = state.use('inline').serialize(node.nodes);
         if (id) {
-            inner = `${inner} {#${id}}`;
+            inner = `${inner} <a id="${id}"></a>`;
         }
 
         return state.shift().write(`${prefix} ${inner}\n\n`);

--- a/test/to-markdown/headings/with-id/output.md
+++ b/test/to-markdown/headings/with-id/output.md
@@ -1,1 +1,1 @@
-# Header {#mycustomid}
+# Header <a id="mycustomid"></a>


### PR DESCRIPTION
Follows #127 and use the `<a />` when serializing custom IDs for headings.