### PR TITLE
Escape HTML from all text nodes

### DIFF
--- a/src/html/inlines/code.js
+++ b/src/html/inlines/code.js
@@ -1,5 +1,4 @@
 import { Serializer, MARKS } from '../../';
-import escape from '../escape';
 
 /**
  * Serialize an inline code to HTML
@@ -7,7 +6,7 @@ import escape from '../escape';
  */
 const serialize = Serializer().transformMarkedLeaf(
     MARKS.CODE,
-    (state, text, mark) => `<code>${escape(text)}</code>`
+    (state, text, mark) => `<code>${text}</code>`
 );
 
 export default { serialize };

--- a/src/html/inlines/escape.js
+++ b/src/html/inlines/escape.js
@@ -3,7 +3,6 @@ import escape from '../escape';
 
 /**
  * Escape all text leaves during serialization.
- * This step should be done before processing text leaves for marks.
  *
  * @type {Serializer}
  */

--- a/src/html/inlines/escape.js
+++ b/src/html/inlines/escape.js
@@ -1,0 +1,18 @@
+import { Serializer } from '../../';
+import escape from '../escape';
+
+/**
+ * Escape all text leaves during serialization.
+ * This step should be done before processing text leaves for marks.
+ *
+ * @type {Serializer}
+ */
+const serialize = Serializer().transformText((state, leaf) => {
+    const { text } = leaf;
+
+    return leaf.merge({
+        text: escape(text)
+    });
+});
+
+export default { serialize };

--- a/src/html/inlines/index.js
+++ b/src/html/inlines/index.js
@@ -1,3 +1,4 @@
+import escape from './escape';
 import code from './code';
 import bold from './bold';
 import italic from './italic';
@@ -9,6 +10,7 @@ import footnoteRef from './footnote-ref';
 import html from './html';
 
 export default [
+    escape,
     code,
     bold,
     italic,

--- a/test/from-html/text/unescaping/input.html
+++ b/test/from-html/text/unescaping/input.html
@@ -1,0 +1,3 @@
+<body>
+    <p>Hello &lt;World&gt;</p>
+</body>

--- a/test/from-html/text/unescaping/output.js
+++ b/test/from-html/text/unescaping/output.js
@@ -1,0 +1,8 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>Hello {'<World>'}</paragraph>
+    </document>
+);

--- a/test/from-markdown/text-escaping/html/input.md
+++ b/test/from-markdown/text-escaping/html/input.md
@@ -1,0 +1,1 @@
+Hello &lt;World&gt;

--- a/test/from-markdown/text-escaping/html/output.js
+++ b/test/from-markdown/text-escaping/html/output.js
@@ -1,0 +1,8 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>Hello {'<World>'}</paragraph>
+    </document>
+);

--- a/test/to-html/text-escaping/input.js
+++ b/test/to-html/text-escaping/input.js
@@ -1,0 +1,8 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>Hello {'<World>'}</paragraph>
+    </document>
+);

--- a/test/to-html/text-escaping/output.html
+++ b/test/to-html/text-escaping/output.html
@@ -1,0 +1,1 @@
+<p>Hello &lt;World&gt;</p>

--- a/test/to-markdown/table/multi-paragraph-html-escaping/input.js
+++ b/test/to-markdown/table/multi-paragraph-html-escaping/input.js
@@ -1,0 +1,18 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <table aligns={[null, null]}>
+            <table_row>
+                <table_cell>
+                    <paragraph>A</paragraph>
+                    <paragraph>B</paragraph>
+                </table_cell>
+                <table_cell>
+                    <paragraph>{'<C>'}</paragraph>
+                </table_cell>
+            </table_row>
+        </table>
+    </document>
+);

--- a/test/to-markdown/table/multi-paragraph-html-escaping/output.md
+++ b/test/to-markdown/table/multi-paragraph-html-escaping/output.md
@@ -1,0 +1,12 @@
+<table>
+  <thead>
+    <tr>
+      <th>
+        <p>A</p>
+        <p>B</p>
+      </th>
+      <th>&lt;C&gt;</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>

--- a/test/to-markdown/text-escaping/html/input.js
+++ b/test/to-markdown/text-escaping/html/input.js
@@ -1,0 +1,8 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>{'<Hello>'} World</paragraph>
+    </document>
+);

--- a/test/to-markdown/text-escaping/html/input.js
+++ b/test/to-markdown/text-escaping/html/input.js
@@ -3,6 +3,6 @@ import h from 'h';
 
 export default (
     <document>
-        <paragraph>{'<Hello>'} World</paragraph>
+        <paragraph>{'<Hello>'} & Bonjour</paragraph>
     </document>
 );

--- a/test/to-markdown/text-escaping/html/output.md
+++ b/test/to-markdown/text-escaping/html/output.md
@@ -1,1 +1,1 @@
-&lt;Hello&gt; World
+&lt;Hello&gt; & Bonjour

--- a/test/to-markdown/text-escaping/html/output.md
+++ b/test/to-markdown/text-escaping/html/output.md
@@ -1,0 +1,1 @@
+&lt;Hello&gt; World


### PR DESCRIPTION
A user reported an issue with Markdown serialization where HTML characters were not escaped. For example, `<C>` would be serialized to `<C>` instead of `&lt;C&gt;`.

See https://github.com/GitbookIO/markup-it/compare/fix/escape-html?expand=1#diff-796e4f3910aef133cdb762f2de0f9629 for the test case.