### PR TITLE
Markdown: Prevent unescaping absolute URLs at deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "htmlparser2": "3.9.2",
     "indent-string": "2.1.0",
     "is": "^3.2.0",
+    "is-absolute-url": "^3.0.0",
     "js-yaml": "^3.7.0",
     "ltrim": "0.0.3",
     "object-values": "^1.0.0",

--- a/src/markdown/utils.js
+++ b/src/markdown/utils.js
@@ -1,5 +1,6 @@
-import { Map } from 'immutable';
 import entities from 'entities';
+import { Map } from 'immutable';
+import isAbsoluteURL from 'is-absolute-url';
 import { escapeWith, unescapeWith } from '../utils/escape';
 
 // Replacements for Markdown escaping
@@ -72,6 +73,12 @@ function escapeURL(str) {
  * @return {String}
  */
 function unescapeURL(str) {
+    // If URL is absolute, we shouldn't try to decode it
+    // since it doesn't represent a file path but rather a static resource
+    if (isAbsoluteURL(str)) {
+        return str;
+    }
+
     let decoded;
     try {
         decoded = decodeURI(str);

--- a/src/markdown/utils.js
+++ b/src/markdown/utils.js
@@ -73,15 +73,11 @@ function escapeURL(str) {
  * @return {String}
  */
 function unescapeURL(str) {
-    // If URL is absolute, we shouldn't try to decode it
-    // since it doesn't represent a file path but rather a static resource
-    if (isAbsoluteURL(str)) {
-        return str;
-    }
-
     let decoded;
     try {
-        decoded = decodeURI(str);
+        // If URL is absolute, we shouldn't try to decode it
+        // since it doesn't represent a file path but rather a static resource
+        decoded = isAbsoluteURL(str) ? str : decodeURI(str);
     } catch (e) {
         if (!(e instanceof URIError)) {
             throw e;

--- a/test/from-markdown/images/markdown-like-url/input.md
+++ b/test/from-markdown/images/markdown-like-url/input.md
@@ -1,0 +1,1 @@
+![progress](https://img.shields.io/[badge]%28/progress-100%25-green.svg%29)

--- a/test/from-markdown/images/markdown-like-url/output.js
+++ b/test/from-markdown/images/markdown-like-url/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>
+            <image
+                alt="progress"
+                src="https://img.shields.io/[badge]%28/progress-100%25-green.svg%29"
+            />
+        </paragraph>
+    </document>
+);

--- a/test/from-markdown/images/with-alt-absolute/input.md
+++ b/test/from-markdown/images/with-alt-absolute/input.md
@@ -1,0 +1,1 @@
+![progress](https://img.shields.io/badge/progress-100%25-green.svg)

--- a/test/from-markdown/images/with-alt-absolute/output.js
+++ b/test/from-markdown/images/with-alt-absolute/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>
+            <image
+                alt="progress"
+                src="https://img.shields.io/badge/progress-100%25-green.svg"
+            />
+        </paragraph>
+    </document>
+);

--- a/test/to-markdown/images/markdown-like-url/input.js
+++ b/test/to-markdown/images/markdown-like-url/input.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>
+            <image
+                alt="progress"
+                src="https://img.shields.io/[badge]%28/progress-100%25-green.svg%29"
+            />
+        </paragraph>
+    </document>
+);

--- a/test/to-markdown/images/markdown-like-url/output.md
+++ b/test/to-markdown/images/markdown-like-url/output.md
@@ -1,0 +1,1 @@
+![progress](https://img.shields.io/[badge]%28/progress-100%25-green.svg%29)

--- a/test/to-markdown/images/with-alt-absolute/input.js
+++ b/test/to-markdown/images/with-alt-absolute/input.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <paragraph>
+            <image
+                alt="progress"
+                src="https://img.shields.io/badge/progress-100%25-green.svg"
+            />
+        </paragraph>
+    </document>
+);

--- a/test/to-markdown/images/with-alt-absolute/output.md
+++ b/test/to-markdown/images/with-alt-absolute/output.md
@@ -1,0 +1,1 @@
+![progress](https://img.shields.io/badge/progress-100%25-green.svg)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,6 +2226,11 @@ is:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/is/-/is-3.2.0.tgz#a362e3daf7df3fd8b7114115d624c5b7e1cb90f7"
 
+is-absolute-url@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.0.tgz#eb21d69df2ed8ef72a3e6f243e216563036a0913"
+  integrity sha512-3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"


### PR DESCRIPTION
Absolute URLs represent static resources instead of file paths, so they should never be unescaped.