### PR TITLE
Fix parsing headings including blocks

### DIFF
--- a/src/markdown/blocks/heading.js
+++ b/src/markdown/blocks/heading.js
@@ -70,6 +70,11 @@ function trimLeftNodesText(nodes) {
     }
 
     const firstNode = nodes.first();
+    // We don't want to trim complicated blocks
+    if (firstNode.object !== 'text') {
+        return nodes;
+    }
+
     const leaves = firstNode.getLeaves();
     const firstLeaf = leaves.first();
 
@@ -95,6 +100,11 @@ function trimRightNodesText(nodes) {
     }
 
     const lastNode = nodes.last();
+    // We don't want to trim complicated blocks
+    if (lastNode.object !== 'text') {
+        return nodes;
+    }
+
     const leaves = lastNode.getLeaves();
     const lastLeaf = leaves.last();
 

--- a/test/from-markdown/headings/link/input.md
+++ b/test/from-markdown/headings/link/input.md
@@ -1,0 +1,1 @@
+#### [Watch the free "Idiomatic Redux" video series](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)

--- a/test/from-markdown/headings/link/output.js
+++ b/test/from-markdown/headings/link/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from 'h';
+
+export default (
+    <document>
+        <header_four>
+            <text />
+            <link href="https://egghead.io/courses/building-react-applications-with-idiomatic-redux">
+                {'Watch the free "Idiomatic Redux" video series'}
+            </link>
+        </header_four>
+    </document>
+);


### PR DESCRIPTION
Trimming the text on first/last node in this case might fail.
We prevent trimming the first/last node of the heading if this is not a text.