### PR TITLE
Revert indent-string@^3.2.0 to be compatible with Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "html": "^1.0.0",
     "htmlclean": "^3.0.8",
     "htmlparser2": "^4.0.0",
-    "indent-string": "^4.0.0",
+    "indent-string": "^3.2.0",
     "is": "^3.3.0",
     "is-absolute-url": "^3.0.3",
     "js-yaml": "^3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2695,11 +2695,6 @@ indent-string@^3.0.0, indent-string@^3.2.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
`indent-string@4.0.0` uses object rest spread