### PR TITLE
Gracefully parse front matter

### DIFF
--- a/__tests__/__fixtures__/from-markdown/frontmatter/invalid/input.md
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/invalid/input.md
@@ -1,0 +1,7 @@
+---
+description: This description
+is on multiple lines instead of
+a single one.
+---
+
+Hello World

--- a/__tests__/__fixtures__/from-markdown/frontmatter/invalid/output.js
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/invalid/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <hr />
+        <paragraph>
+            description: This description is on multiple lines instead of
+        </paragraph>
+        <header_two>a single one.</header_two>
+        <paragraph>Hello World</paragraph>
+    </document>
+);

--- a/__tests__/__fixtures__/from-markdown/frontmatter/non-parsable/input.md
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/non-parsable/input.md
@@ -1,0 +1,5 @@
+---
+This front matter is just a big line of text
+---
+
+Hello World

--- a/__tests__/__fixtures__/from-markdown/frontmatter/non-parsable/output.js
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/non-parsable/output.js
@@ -1,0 +1,10 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <hr />
+        <header_two>This front matter is just a big line of text</header_two>
+        <paragraph>Hello World</paragraph>
+    </document>
+);

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "detect-newline": "^2.1.0",
     "entities": "^2.0.0",
     "escape-string-regexp": "^2.0.0",
-    "front-matter": "^3.0.2",
+    "gray-matter": "^4.0.2",
     "html": "^1.0.0",
     "htmlclean": "^3.0.8",
     "htmlparser2": "^4.0.0",

--- a/src/markdown/document.js
+++ b/src/markdown/document.js
@@ -1,6 +1,6 @@
 import { Document } from '@gitbook/slate';
 import { safeDump as safeDumpYAML } from 'js-yaml';
-import fm from 'front-matter';
+import gm from 'gray-matter';
 import Immutable from 'immutable';
 import { Deserializer, Serializer } from '../models';
 
@@ -32,10 +32,30 @@ const serialize = Serializer()
  */
 const deserialize = Deserializer().then(state => {
     const { text } = state;
-    const parsed = fm(text);
 
-    const nodes = state.use('block').deserialize(parsed.body);
-    const data = Immutable.fromJS(parsed.attributes);
+    // Parse front matter gracefully
+    // If we can't parse it, or the content is only a string, we parse at using
+    // the classic MarkdownParser rules
+    let parsedContent = '';
+    let parsedData = {};
+
+    try {
+        const parsed = gm(text);
+        ({ content: parsedContent, data: parsedData } = parsed);
+    } catch (error) {
+        // In case of error, we leave the data empty and parse the whole text
+        parsedContent = text;
+    }
+
+    // In case we parsed front matter as a simple string,
+    // we parse the whole text
+    if (typeof parsedData === 'string') {
+        parsedContent = text;
+        parsedData = {};
+    }
+
+    const nodes = state.use('block').deserialize(parsedContent);
+    const data = Immutable.fromJS(parsedData);
 
     const node = Document.create({
         data,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,13 +2415,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-front-matter@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-3.0.2.tgz#2401cd05fcf22bd0de48a104ffb4efb1ff5c8465"
-  integrity sha512-iBGZaWyzqgsrPGsqrXZP6N4hp5FzSKDi18nfAoYpgz3qK5sAwFv/ojmn3VS60SOgLvq6CtojNqy0y6ZNz05IzQ==
-  dependencies:
-    js-yaml "^3.13.1"
-
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -2525,6 +2518,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+gray-matter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.2.tgz#9aa379e3acaf421193fce7d2a28cebd4518ac454"
+  integrity sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==
+  dependencies:
+    js-yaml "^3.11.0"
+    kind-of "^6.0.2"
+    section-matter "^1.0.0"
+    strip-bom-string "^1.0.0"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -3377,7 +3380,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.9.1:
+js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.9.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   dependencies:
@@ -4636,6 +4639,14 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+section-matter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/section-matter/-/section-matter-1.0.0.tgz#e9041953506780ec01d59f292a19c7b850b84167"
+  integrity sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==
+  dependencies:
+    extend-shallow "^2.0.1"
+    kind-of "^6.0.0"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -4884,6 +4895,11 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-bom-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
+  integrity sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Currently, invalid front matter makes the deserialization using the `MarkdownParser` fail, either with a `YAMLException` (error from `front-matter`) or a `Expected [K, V] tuple: T` error (when passing a string instead of an object to `Immutable.fromJS()`).

This PR handles these errors gracefully by switching to the more compliant `gray-matter` module.
In case of error or if the text front matter is a simple string, we parse the whole text as pure markdown.