### PR TITLE
Gracefully parse front matter

### DIFF
--- a/__tests__/__fixtures__/from-markdown/frontmatter/invalid/input.md
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/invalid/input.md
@@ -1,0 +1,7 @@
+---
+description: This description
+is on multiple lines instead of
+a single one.
+---
+
+Hello World

--- a/__tests__/__fixtures__/from-markdown/frontmatter/invalid/output.js
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/invalid/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <hr />
+        <paragraph>
+            description: This description is on multiple lines instead of
+        </paragraph>
+        <header_two>a single one.</header_two>
+        <paragraph>Hello World</paragraph>
+    </document>
+);

--- a/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-2/input.md
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-2/input.md
@@ -1,0 +1,7 @@
+----
+description: This description
+is on multiple lines instead of
+a single one.
+---
+
+Hello World

--- a/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-2/output.js
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-2/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <hr />
+        <paragraph>
+            description: This description is on multiple lines instead of
+        </paragraph>
+        <header_two>a single one.</header_two>
+        <paragraph>Hello World</paragraph>
+    </document>
+);

--- a/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-3/input.md
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-3/input.md
@@ -1,0 +1,7 @@
+----
+description: This description
+is on multiple lines instead of
+a single one.
+----
+
+Hello World

--- a/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-3/output.js
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter-3/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <hr />
+        <paragraph>
+            description: This description is on multiple lines instead of
+        </paragraph>
+        <header_two>a single one.</header_two>
+        <paragraph>Hello World</paragraph>
+    </document>
+);

--- a/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter/input.md
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter/input.md
@@ -1,0 +1,7 @@
+---
+description: This description
+is on multiple lines instead of
+a single one.
+----
+
+Hello World

--- a/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter/output.js
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/looks-like-front-matter/output.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <hr />
+        <paragraph>
+            description: This description is on multiple lines instead of
+        </paragraph>
+        <header_two>a single one.</header_two>
+        <paragraph>Hello World</paragraph>
+    </document>
+);

--- a/__tests__/__fixtures__/from-markdown/frontmatter/only-string/input.md
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/only-string/input.md
@@ -1,0 +1,5 @@
+---
+This front matter is just a big line of text
+---
+
+Hello World

--- a/__tests__/__fixtures__/from-markdown/frontmatter/only-string/output.js
+++ b/__tests__/__fixtures__/from-markdown/frontmatter/only-string/output.js
@@ -1,0 +1,10 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <hr />
+        <header_two>This front matter is just a big line of text</header_two>
+        <paragraph>Hello World</paragraph>
+    </document>
+);

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "detect-newline": "^2.1.0",
     "entities": "^2.0.0",
     "escape-string-regexp": "^2.0.0",
-    "front-matter": "^3.0.2",
+    "front-matter": "^3.1.0",
     "html": "^1.0.0",
     "htmlclean": "^3.0.8",
     "htmlparser2": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,10 +2415,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-front-matter@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-3.0.2.tgz#2401cd05fcf22bd0de48a104ffb4efb1ff5c8465"
-  integrity sha512-iBGZaWyzqgsrPGsqrXZP6N4hp5FzSKDi18nfAoYpgz3qK5sAwFv/ojmn3VS60SOgLvq6CtojNqy0y6ZNz05IzQ==
+front-matter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-3.1.0.tgz#a0b758c3c6c39ce43e107dd0909a57d42964c2de"
+  integrity sha512-RFEK8N6waWTdwBZOPNEtvwMjZ/hUfpwXkYUYkmmOhQGdhSulXhWrFwiUhdhkduLDiIwbROl/faF1X/PC/GGRMw==
   dependencies:
     js-yaml "^3.13.1"
 


### PR DESCRIPTION
_Better alternative to #150 (`gray-matter` incorrectly detects content as front matter when there is no delimiter)._

Currently, invalid front matter makes the deserialization using the MarkdownParser fail, either with a `YAMLException` (error from front-matter) or a `Expected [K, V] tuple: T` error (when passing a string instead of an object to Immutable.fromJS()).

This PR handles these errors gracefully. In case of error or if the text front matter is a simple string, we parse the whole text as pure markdown.