### PR TITLE
Ensure HTML tables in markdown are properly followed by newlines

### DIFF
--- a/__tests__/__fixtures__/to-markdown/table/html-table-and-paragraph/input.js
+++ b/__tests__/__fixtures__/to-markdown/table/html-table-and-paragraph/input.js
@@ -1,0 +1,19 @@
+/** @jsx h */
+import h from '../../../hyperscript';
+
+export default (
+    <document>
+        <table aligns={[null, null]}>
+            <table_row>
+                <table_cell>
+                    <paragraph>A</paragraph>
+                    <paragraph>B</paragraph>
+                </table_cell>
+                <table_cell>
+                    <paragraph>{'<C>'}</paragraph>
+                </table_cell>
+            </table_row>
+        </table>
+        <paragraph>Some text</paragraph>
+    </document>
+);

--- a/__tests__/__fixtures__/to-markdown/table/html-table-and-paragraph/output.md
+++ b/__tests__/__fixtures__/to-markdown/table/html-table-and-paragraph/output.md
@@ -1,0 +1,14 @@
+<table>
+  <thead>
+    <tr>
+      <th>
+        <p>A</p>
+        <p>B</p>
+      </th>
+      <th>&lt;C&gt;</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+
+Some text

--- a/src/markdown/blocks/table.js
+++ b/src/markdown/blocks/table.js
@@ -57,7 +57,7 @@ const serialize = Serializer()
                     nodes: [table]
                 })
             );
-            return state.shift().write(htmlOutput);
+            return state.shift().write(`${htmlOutput}\n\n`);
         }
 
         const { data, nodes } = table;


### PR DESCRIPTION
When exporting a complex `table` to markdown, it is written as HTML to preserve formatting.

However, `markup-it` currently doesn't append newline characters `\n\n` after the HTML table in the markdown output.
This leads to invalid markdown when the table is not the last element of content, for instance:

```html
<table aligns={[null, null]}>
    ...
</table>
<paragraph>Some text</paragraph>
```

leads to

```md
<table>
  ...
</table>Some text
```

instead of

```md
<table>
  ...
</table>

Some text
```

This PR fixes this issue by properly appending newline characters after the HTML table in markdown.